### PR TITLE
Fixes for glue extractor - for tables with BIG schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .DS_Store
 mock_path
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
 .DS_Store
+.vscode
 mock_path
 dist/

--- a/carte_cli/extractor/glue_extractor.py
+++ b/carte_cli/extractor/glue_extractor.py
@@ -54,12 +54,7 @@ class GlueExtractor(Extractor):
             schema_parts_count = int(
                 row["Parameters"]["spark.sql.sources.schema.numParts"]
             )
-            schema_str = ""
-            for part in range(0, schema_parts_count):
-                schema_str = (
-                    schema_str
-                    + row["Parameters"][f"spark.sql.sources.schema.part.{part}"]
-                )
+schema_str = ''.join([row["Parameters"][f"spark.sql.sources.schema.part.{part}"] for part in range(schema_parts_count)])
             schema = json.loads(schema_str)
         else:
             print(table_name)

--- a/carte_cli/extractor/glue_extractor.py
+++ b/carte_cli/extractor/glue_extractor.py
@@ -6,7 +6,7 @@ from pyhocon import ConfigTree
 from typing import Iterator, Union, Dict, Any, List
 from databuilder.extractor.base_extractor import Extractor
 from carte_cli.model.carte_table_model import TableMetadata, ColumnMetadata, TableType
-
+import json
 
 class GlueExtractor(Extractor):
     def __init__(self, connection_name: str):
@@ -41,6 +41,34 @@ class GlueExtractor(Extractor):
         else:
             return col_type
 
+    def _get_glue_table_columns(self, row: Dict[str, Any], table_name: str) -> List[ColumnMetadata]:
+        columns = []
+        if "spark.sql.sources.schema" in row["Parameters"]:
+            # For delta and parquet tables if the schema is not too big   
+            schema = json.loads(row["Parameters"]["spark.sql.sources.schema"])                    
+        elif 'spark.sql.sources.schema.numParts' in row["Parameters"]:
+            # If the delta or parquet table's schema is very big, glue separates it to multiple properties ¯\_(ツ)_/¯
+            schema_parts_count = int(row["Parameters"]["spark.sql.sources.schema.numParts"])
+            schema_str = ""
+            for part in range(0,schema_parts_count):
+                schema_str = schema_str+row["Parameters"][f"spark.sql.sources.schema.part.{part}"]                       
+            schema = json.loads(schema_str)
+        else:
+            print(table_name)
+            print(row)
+            raise Exception("Unsupported glue table format")
+        fields = schema["fields"]
+        for column in fields:
+            columns.append(
+                ColumnMetadata(
+                    name=column["name"],
+                    column_type=self._get_column_type(column),
+                    description=None,
+                )
+            )
+        return columns
+    
+        
     def _get_extract_iter(self) -> Iterator[TableMetadata]:
         for row in self._get_raw_extract_iter():
             columns = []
@@ -56,6 +84,7 @@ class GlueExtractor(Extractor):
             is_view = row.get("TableType") == "VIRTUAL_VIEW"
 
             if is_view:
+                table_type = TableType.VIEW
                 for column in row["StorageDescriptor"]["Columns"]:
                     columns.append(
                         ColumnMetadata(
@@ -64,19 +93,9 @@ class GlueExtractor(Extractor):
                             description=None,
                         )
                     )
-            else:
-                # This solution is more robust for Delta and Parquet tables.
-                # Both table types has these fields
-                for column in row["Parameters"]["spark.sql.sources.schema"]["fields"]:
-                    columns.append(
-                        ColumnMetadata(
-                            name=column["name"],
-                            column_type=self._get_column_type(column),
-                            description=None,
-                        )
-                    )
-
-            table_type = TableType.VIEW if is_view else TableType.TABLE
+            else:                             
+                columns = self._get_glue_table_columns(row, full_table_name)
+                table_type = TableType.TABLE
 
             yield TableMetadata(
                 name=table_name,

--- a/carte_cli/extractor/glue_extractor.py
+++ b/carte_cli/extractor/glue_extractor.py
@@ -9,6 +9,11 @@ from carte_cli.model.carte_table_model import TableMetadata, ColumnMetadata, Tab
 import json
 
 
+class GlueExtractorException(Exception):
+    def __init__(self, *args: object) -> None:
+        super().__init__(*args)
+
+
 class GlueExtractor(Extractor):
     def __init__(self, connection_name: str):
         super().__init__()
@@ -54,12 +59,17 @@ class GlueExtractor(Extractor):
             schema_parts_count = int(
                 row["Parameters"]["spark.sql.sources.schema.numParts"]
             )
-schema_str = ''.join([row["Parameters"][f"spark.sql.sources.schema.part.{part}"] for part in range(schema_parts_count)])
+            schema_str = "".join(
+                [
+                    row["Parameters"][f"spark.sql.sources.schema.part.{part}"]
+                    for part in range(schema_parts_count)
+                ]
+            )
             schema = json.loads(schema_str)
         else:
-            print(table_name)
-            print(row)
-            raise Exception("Unsupported glue table format")
+            raise GlueExtractorException(
+                f"Unsupported glue table format for {table_name}", row
+            )
         fields = schema["fields"]
         for column in fields:
             columns.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carte-cli"
-version = "0.3.20"
+version = "0.3.21"
 description = "A static site generator for data catalogs"
 authors = ["Balint Haller <balint@hey.com>"]
 license = "GPL-3.0-or-later"

--- a/tests/extractor/test_glue_extractor.py
+++ b/tests/extractor/test_glue_extractor.py
@@ -62,46 +62,46 @@ class TestGlueExtractor(unittest.TestCase):
                     ],
                     "TableType": "EXTERNAL_TABLE",
                     "Parameters": {
-                        "spark.sql.sources.schema": {
+                        "spark.sql.sources.schema": """{
                             "type": "struct",
                             "fields": [
                                 {
                                     "name": "col_id1",
                                     "type": "bigint",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "col_id2",
                                     "type": "bigint",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "source",
                                     "type": "varchar",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "is_active",
                                     "type": "boolean",
-                                    "nullable": True,
+                                    "nullable": "True"
                                 },
                                 {
                                     "name": "etl_created_at",
                                     "type": "timestamp",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "partition_key1",
                                     "type": "string",
-                                    "nullable": True,
-                                    "metadata": {},
-                                },
-                            ],
-                        }
+                                    "nullable": "True",
+                                    "metadata": {}
+                                }
+                            ]
+                        }"""
                     },
                 }
             ]
@@ -159,35 +159,35 @@ class TestGlueExtractor(unittest.TestCase):
                     ],
                     "TableType": "EXTERNAL_TABLE",
                     "Parameters": {
-                        "spark.sql.sources.schema": {
+                        "spark.sql.sources.schema": """{
                             "type": "struct",
                             "fields": [
                                 {
                                     "name": "col_id1",
                                     "type": "bigint",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "source",
                                     "type": "varchar",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "ds",
                                     "type": "varchar",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "partition_key1",
                                     "type": "string",
-                                    "nullable": True,
-                                    "metadata": {},
-                                },
-                            ],
-                        }
+                                    "nullable": "True",
+                                    "metadata": {}
+                                }
+                            ]
+                        }"""
                     },
                 },
                 {
@@ -216,20 +216,20 @@ class TestGlueExtractor(unittest.TestCase):
                     },
                     "TableType": "EXTERNAL_TABLE",
                     "Parameters": {
-                        "spark.sql.sources.schema": {
+                        "spark.sql.sources.schema": """{
                             "type": "struct",
                             "fields": [
                                 {
                                     "name": "col_name",
                                     "type": "varchar",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "col_name2",
                                     "type": "varchar",
-                                    "nullable": True,
-                                    "metadata": {},
+                                    "nullable": "True",
+                                    "metadata": {}
                                 },
                                 {
                                     "name": "event_properties",
@@ -237,13 +237,13 @@ class TestGlueExtractor(unittest.TestCase):
                                         "type": "map",
                                         "keyType": "string",
                                         "valueType": "string",
-                                        "valueContainsNull": True,
+                                        "valueContainsNull": "True"
                                     },
-                                    "nullable": True,
-                                    "metadata": {},
-                                },
-                            ],
-                        }
+                                    "nullable": "True",
+                                    "metadata": {}
+                                }
+                            ]
+                        }"""
                     },
                 },
                 {

--- a/tests/extractor/test_glue_extractor.py
+++ b/tests/extractor/test_glue_extractor.py
@@ -247,6 +247,48 @@ class TestGlueExtractor(unittest.TestCase):
                     },
                 },
                 {
+                    "Name": "big_schema_test_table",
+                    "DatabaseName": "test_schema1",
+                    "Description": "test table for big schema",
+                    "TableType": "EXTERNAL_TABLE",
+                    "StorageDescriptor": {
+                        "Location": "test_location3",
+                    },
+                    "Parameters": {
+                        "spark.sql.sources.schema.numParts": "2",
+                        "spark.sql.sources.schema.part.0": """{
+                            "type": "struct",
+                            "fields": [
+                                {
+                                    "name": "col_name",
+                                    "type": "varchar",
+                                    "nullable": "Tr""",
+                        "spark.sql.sources.schema.part.1": """ue",
+                                    "metadata": {}
+                                },
+                                {
+                                    "name": "col_name2",
+                                    "type": "varchar",
+                                    "nullable": "True",
+                                    "metadata": {}
+                                },
+                                {
+                                    "name": "event_properties",
+                                    "type": {
+                                        "type": "map",
+                                        "keyType": "string",
+                                        "valueType": "string",
+                                        "valueContainsNull": "True"
+                                    },
+                                    "nullable": "True",
+                                    "metadata": {}
+                                }
+                            ]
+                        }
+                        """,
+                    },
+                },
+                {
                     "Name": "test_view1",
                     "DatabaseName": "test_schema1",
                     "Description": "test view 1",
@@ -316,6 +358,21 @@ class TestGlueExtractor(unittest.TestCase):
                 database="test_schema1",
                 description=None,
                 location="test_location2",
+                table_type=TableType.TABLE,
+                columns=[
+                    ColumnMetadata("col_name", "varchar", None),
+                    ColumnMetadata("col_name2", "varchar", None),
+                    ColumnMetadata("event_properties", "map<string,string>", None),
+                ],
+            )
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = TableMetadata(
+                name="big_schema_test_table",
+                connection="test-connection",
+                database="test_schema1",
+                description=None,
+                location="test_location3",
                 table_type=TableType.TABLE,
                 columns=[
                     ColumnMetadata("col_name", "varchar", None),


### PR DESCRIPTION
Some tables might have 60-70 columns, in this case GLUE stores the schema in splitted texts.

Under the Parameters JSON object there is:
`'spark.sql.sources.schema.numParts':'3'`
Which indicates how many parts is the big schema splitted to.
Then the strings that we need to concatenate are under:
`'spark.sql.sources.schema.part.0'`
`'spark.sql.sources.schema.part.1'`
`'spark.sql.sources.schema.part.2'`

By concatenating these parts we get a Valid JSON, that is possible to parse in Python.

